### PR TITLE
Fix error handling response and handler signature

### DIFF
--- a/src/main/java/backend_lingua/linguas/util/dto/response/ErrorMessageResponse.kt
+++ b/src/main/java/backend_lingua/linguas/util/dto/response/ErrorMessageResponse.kt
@@ -11,8 +11,8 @@ data class ErrorMessageResponse(
     companion object {
         fun of(message: String, httpRequest: HttpServletRequest, exception: Exception): ErrorMessageResponse {
             return ErrorMessageResponse(
-                httpMethod = httpRequest.method.toString(),
-                path = httpRequest.method,
+                httpMethod = httpRequest.method,
+                path = httpRequest.requestURI,
                 message = message,
                 exception = exception
             )

--- a/src/main/java/backend_lingua/linguas/util/exception/ExceptionHandlerImpl.kt
+++ b/src/main/java/backend_lingua/linguas/util/exception/ExceptionHandlerImpl.kt
@@ -8,15 +8,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 
 @RestControllerAdvice
-class ExceptionHandlerImpl() {
+class ExceptionHandlerImpl {
 
     @ExceptionHandler(BusinessException::class)
-    fun handlerBusinessException(e: BusinessException, request: HttpServletRequest,exception: Exception): ResponseEntity<ErrorMessageResponse> {
+    fun handleBusinessException(
+        e: BusinessException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorMessageResponse> {
         return ResponseEntity
             .status(e.httpStatus)
-            .body(ErrorMessageResponse.of(
-                e.message ,
-                request ,
-                exception))
+            .body(
+                ErrorMessageResponse.of(
+                    e.message,
+                    request,
+                    e,
+                )
+            )
     }
 }


### PR DESCRIPTION
## Summary
- correct business exception handler signature
- fix wrong path info in error message response

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching: {languageVersion=17})*


------
https://chatgpt.com/codex/tasks/task_e_689060fd53b48333b206eb14683d5e7c