### PR TITLE
✨ Feat: Add mock auth server & test pages for business sign-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ repositories { mavenCentral() }
 dependencies {
     /* ───────── Spring Boot ───────── */
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // 👈 추가
+
     // implementation 'org.springframework.boot:spring-boot-starter-webflux' // ❌ 같이 쓰지 말기
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/backend_lingua/linguas/domain/member/api/UserController.java
+++ b/src/main/java/backend_lingua/linguas/domain/member/api/UserController.java
@@ -1,0 +1,30 @@
+package backend_lingua.linguas.domain.member.api;
+
+import backend_lingua.linguas.domain.member.dto.MemberInfo;
+import backend_lingua.linguas.infrastructure.security.principal.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+    @GetMapping("/user/profile")
+    public ResponseEntity<MemberInfo> getUserProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        log.info("Get User Profile = {}" ,userPrincipal.toString() );
+
+        MemberInfo member = MemberInfo.from(userPrincipal.getMember());
+        return ResponseEntity.ok(member);
+    }
+
+
+}

--- a/src/main/java/backend_lingua/linguas/domain/member/api/ViewController.java
+++ b/src/main/java/backend_lingua/linguas/domain/member/api/ViewController.java
@@ -1,0 +1,25 @@
+package backend_lingua.linguas.domain.member.api;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ViewController {
+
+    @Value("${kakao.js-key}")
+    private String kakaoJsKey;
+
+    @GetMapping("/login")
+    public String login(Model model) {
+        model.addAttribute("kakaoJsKey", kakaoJsKey);
+        return "login";
+    }
+
+    @GetMapping("/profile")
+    public String profile() {
+        return "profile"; // templates/profile.html
+    }
+}

--- a/src/main/java/backend_lingua/linguas/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/backend_lingua/linguas/infrastructure/security/config/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
                 // 요청 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
                         // Public endpoints
+                        .requestMatchers("/", "/login", "/profile").permitAll()
+                        .requestMatchers("/js/**", "/css/**", "/images/**").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers(
                                 "/",
                                 "/error",

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,6 +20,9 @@ kanji:
   api:
     base-url: ${KANJI_API_BASE_URL}
 
+kakao:
+  js-key: ${KAKAO_JS_KEY}
+
 spring:
   cloud:
     aws:

--- a/src/main/resources/static/js/auth.js
+++ b/src/main/resources/static/js/auth.js
@@ -1,0 +1,161 @@
+// ===== 공통 LocalStorage 키 =====
+const LS = {
+    access:  'jwt_access_token',
+    refresh: 'jwt_refresh_token',
+    member:  'member_info' // 선택 저장
+};
+
+// ===== 카카오 SDK 초기화 & 로그인 플로우 =====
+function initKakao() {
+    const key = window.KAKAO_JS_KEY || document.querySelector('meta[name="kakao-js-key"]')?.content;
+    if (!key) {
+        console.warn('Kakao JS Key가 설정되지 않았습니다. window.KAKAO_JS_KEY에 키를 넣어주세요.');
+        return;
+    }
+    if (!window.Kakao?.isInitialized?.()) {
+        window.Kakao.init(key);
+    }
+}
+
+async function kakaoLoginAndExchange() {
+    return new Promise((resolve, reject) => {
+        if (!window.Kakao) return reject(new Error('Kakao SDK 미로딩'));
+        window.Kakao.Auth.login({
+            scope: 'profile_nickname, profile_image, account_email',
+            success: async (authObj) => {
+                try {
+                    const providerAccessToken = authObj.access_token; // 클라이언트용 카카오 액세스 토큰
+                    // 서버에 교환 요청 (본문: text/plain)
+                    const res = await fetch('/api/v1/auth/login/kakao', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'text/plain' },
+                        body: providerAccessToken
+                    });
+                    if (!res.ok) {
+                        const txt = await res.text();
+                        throw new Error(`로그인 실패: ${res.status} ${txt}`);
+                    }
+                    const data = await res.json();
+                    // TokenInfo 추정 필드 매핑(서버 DTO에 맞게 조정)
+                    const tokenInfo = data.tokenInfo || data.token || data;
+                    const accessToken  = tokenInfo.accessToken  || tokenInfo.access_token;
+                    const refreshToken = tokenInfo.refreshToken || tokenInfo.refresh_token;
+
+                    if (!accessToken) throw new Error('서버에서 accessToken을 찾을 수 없습니다.');
+
+                    // 저장
+                    localStorage.setItem(LS.access, accessToken);
+                    if (refreshToken) localStorage.setItem(LS.refresh, refreshToken);
+                    if (data.memberInfo) localStorage.setItem(LS.member, JSON.stringify(data.memberInfo));
+
+                    resolve();
+                } catch (e) { reject(e); }
+            },
+            fail: (err) => reject(err)
+        });
+    });
+}
+
+// ===== 프로필 API 호출 =====
+async function loadProfile() {
+    const access = localStorage.getItem(LS.access);
+    if (!access) throw new Error('로그인이 필요합니다.');
+
+    const res = await fetch('/api/user/profile', {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${access}` }
+    });
+    if (!res.ok) throw new Error(`프로필 조회 실패: ${res.status}`);
+    return res.json();
+}
+
+// ===== 로그아웃 =====
+async function logout() {
+    const refresh = localStorage.getItem(LS.refresh);
+    // 서버는 Refresh-Token 헤더로 로그아웃 처리
+    await fetch('/api/v1/auth/logout', {
+        method: 'POST',
+        headers: refresh ? { 'Refresh-Token': refresh } : {}
+    });
+    // 로컬 삭제
+    localStorage.removeItem(LS.access);
+    localStorage.removeItem(LS.refresh);
+    localStorage.removeItem(LS.member);
+}
+
+// ===== 페이지별 초기화 =====
+document.addEventListener('DOMContentLoaded', async () => {
+    const path = location.pathname;
+
+    // 로그인 페이지
+    if (path === '/' || path === '/login') {
+        initKakao();
+        const btn = document.getElementById('kakaoLoginBtn');
+        const errorBox = document.getElementById('errorBox');
+        if (btn) {
+            btn.addEventListener('click', async () => {
+                errorBox.style.display = 'none';
+                try {
+                    await kakaoLoginAndExchange(); // 카카오 토큰 → 서버 로그인(JWT)
+                    location.href = '/profile';
+                } catch (e) {
+                    console.error(e);
+                    errorBox.textContent = e?.message || '로그인 중 오류가 발생했습니다.';
+                    errorBox.style.display = 'block';
+                }
+            });
+        }
+    }
+
+    // 프로필 페이지
+    if (path === '/profile') {
+        const toHomeBtn = document.getElementById('toHomeBtn');
+        const logoutBtn = document.getElementById('logoutBtn');
+        const err = document.getElementById('errorBox');
+
+        if (toHomeBtn) toHomeBtn.addEventListener('click', () => location.href = '/');
+
+        if (logoutBtn) {
+            logoutBtn.addEventListener('click', async () => {
+                try {
+                    await logout();
+                } finally {
+                    location.href = '/login';
+                }
+            });
+        }
+
+        try {
+            const profile = await loadProfile();
+            // 예상 가능한 필드 우선 표시(없으면 대체)
+            const nickname = profile.nickname || profile.name || profile.username || '사용자';
+            const email    = profile.email || '—';
+            const provider = profile.providerType || profile.provider || '—';
+            const role     = profile.role || profile.memberRole || '—';
+            const id       = profile.id || profile.memberId || '—';
+
+            document.getElementById('nickname').textContent   = nickname;
+            document.getElementById('email').textContent      = email;
+            document.getElementById('kv-nickname').textContent= nickname;
+            document.getElementById('kv-email').textContent   = email;
+            document.getElementById('kv-provider').textContent= provider;
+            document.getElementById('kv-role').textContent    = role;
+            document.getElementById('kv-id').textContent      = id;
+
+            // 멤버 속에 profileImage 같은 필드가 있으면 적용
+            const avatarUrl = profile.profileImage || profile.imageUrl || profile.avatarUrl || null;
+            if (avatarUrl) document.getElementById('avatar').src = avatarUrl;
+
+            // 원본 JSON 출력
+            document.getElementById('rawJson').textContent = JSON.stringify(profile, null, 2);
+        } catch (e) {
+            console.error(e);
+            if (err) {
+                err.textContent = e?.message || '프로필을 불러오는 중 오류가 발생했습니다.';
+                err.style.display = 'block';
+            }
+            // 토큰 만료 시 로그인으로
+            setTimeout(() => location.href = '/login', 800);
+        }
+    }
+});

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>카카오 로그인</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!-- 필요시 서버에서 주입: <meta name="kakao-js-key" th:content="${kakaoJsKey}"/> -->
+    <style>
+        :root { color-scheme: light dark; }
+        body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; background:#f7f7f8; }
+        .container { min-height:100dvh; display:grid; place-items:center; }
+        .card { background:#fff; width:min(420px,92vw); padding:28px; border-radius:16px; box-shadow:0 10px 30px rgba(0,0,0,.08); }
+        h1 { margin:0 0 10px; font-size:1.3rem; }
+        p { margin:0 0 18px; color:#666; }
+        button.kakao { width:100%; display:flex; align-items:center; justify-content:center; gap:8px;
+            padding:12px 16px; border-radius:10px; border:1px solid #e5e5e5; background:#FEE500; font-weight:700; cursor:pointer; }
+        .hint { margin-top:12px; font-size:.9rem; color:#888; text-align:center; }
+        .err { margin-top:12px; color:#c00; font-size:.9rem; display:none; }
+    </style>
+    <script src="https://developers.kakao.com/sdk/js/kakao.min.js" defer></script>
+    <script src="/js/auth.js" defer></script>
+    <script>
+        window.KAKAO_JS_KEY = /*[[${kakaoJsKey}]]*/ '';
+    </script>
+</head>
+<body>
+<div class="container">
+    <section class="card">
+        <h1>카카오 로그인</h1>
+        <p>카카오로 로그인하면 JWT가 발급되고, 프로필 페이지에서 내 정보를 볼 수 있어요.</p>
+
+        <button id="kakaoLoginBtn" class="kakao" type="button" aria-label="카카오로 로그인">
+            <img alt="kakao" src="https://t1.kakaocdn.net/kakaocorp/kakaocorp/admin/ico_friends.png" width="20" height="20">
+            카카오로 로그인
+        </button>
+
+        <div id="errorBox" class="err"></div>
+        <div class="hint">로그인 성공 시 자동으로 프로필 페이지로 이동합니다.</div>
+    </section>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>내 프로필</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>
+        :root { color-scheme: light dark; }
+        body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; background:#f7f7f8; }
+        header { position:sticky; top:0; background:#fff; border-bottom:1px solid #eee; padding:12px 16px; display:flex; justify-content:space-between; align-items:center; }
+        .brand { font-weight:800; }
+        .btn { padding:8px 12px; border-radius:8px; border:1px solid #ddd; background:#fff; cursor:pointer; }
+        main { padding:22px 16px; display:grid; place-items:center; }
+        .card { background:#fff; width:min(760px,94vw); padding:24px; border-radius:16px; box-shadow:0 10px 30px rgba(0,0,0,.08); }
+        .row { display:grid; grid-template-columns: 160px 1fr; gap:10px 14px; }
+        .key { color:#666; }
+        .val { font-weight:600; }
+        pre { background:#fafafa; padding:14px; border-radius:10px; overflow:auto; }
+        .avatar { width:96px; height:96px; border-radius:50%; object-fit:cover; border:1px solid #eee; }
+        .top { display:flex; gap:16px; align-items:center; margin-bottom:16px; }
+        .err { color:#c00; margin-top:8px; }
+    </style>
+    <script src="/js/auth.js" defer></script>
+</head>
+<body>
+<header>
+    <div class="brand">내 프로필</div>
+    <div>
+        <button id="toHomeBtn" class="btn" type="button">홈</button>
+        <button id="logoutBtn" class="btn" type="button">로그아웃</button>
+    </div>
+</header>
+
+<main>
+    <section class="card">
+        <div class="top">
+            <img id="avatar" class="avatar" alt="profile image" src="https://placehold.co/192x192?text=No+Image" />
+            <div>
+                <h2 id="nickname">사용자</h2>
+                <div id="email" style="color:#888">—</div>
+            </div>
+        </div>
+
+        <div class="row" style="margin-bottom:16px;">
+            <div class="key">닉네임</div><div id="kv-nickname" class="val">—</div>
+            <div class="key">이메일</div><div id="kv-email" class="val">—</div>
+            <div class="key">제공자(Provider)</div><div id="kv-provider" class="val">—</div>
+            <div class="key">권한(Role)</div><div id="kv-role" class="val">—</div>
+            <div class="key">회원 ID</div><div id="kv-id" class="val">—</div>
+        </div>
+
+        <div>
+            <div class="key" style="margin-bottom:6px;">원본 JSON</div>
+            <pre id="rawJson">{}</pre>
+            <div id="errorBox" class="err" style="display:none;"></div>
+        </div>
+    </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## 🔍 이 PR에서 해결하고자 하는 문제는 무엇인가요?

외부 비즈니스 인증 연동을 위해 실제 서비스 API 호출 전 Mock 서버 및 테스트 페이지가 필요했습니다.


## ✨ 이 PR에서 주요하게 변경한 점은 무엇인가요?

- Mock 인증 서버 구성
  - UserController: GET /api/user/profile 엔드포인트 추가 (로그인 사용자 정보 반환)
  - ViewController: /login, /profile 뷰 제공
- 프론트엔드 테스트 페이지 추가
  - login.html, profile.html 템플릿 추가
  - auth.js: 카카오 JS SDK 연동, 토큰 교환 및 localStorage 저장 로직 구현
- 보안 및 설정
  - SecurityConfig: 공개 라우트(/login, /profile, 정적 리소스) 허용
  - application.yml: kakao.js-key 프로퍼티 추가 (서버에서 뷰로 주입 가능)
- 빌드 설정
  - build.gradle: spring-boot-starter-thymeleaf 의존성 추가

## 🔖 주요 변경점 외에 추가로 변경된 부분이 있나요?

없음

## 🙏🏻 Reviewer가 특히 확인해주었으면 하는 부분이 있나요?

없음

## 🩺 이 PR에서 테스트나 검증이 필요한 부분이 있나요?

없음

## 📚 관련된 Issue, Jira, 문서

없음

