### PR TITLE
♻️ Refactor: Simplify MobileAuthController endpoint mappings

### DIFF
--- a/src/main/java/backend_lingua/linguas/domain/oauth/api/MobileAuthController.java
+++ b/src/main/java/backend_lingua/linguas/domain/oauth/api/MobileAuthController.java
@@ -29,7 +29,7 @@ public class MobileAuthController {
             summary = "소셜 로그인",
             description = "제공처의 액세스 토큰으로 회원 정보 조회, 로그인 처리 후 액세스 토큰과 회원 정보를 응답으로 전송"
     )
-    @PostMapping(value = "/login/{provider}", consumes = MediaType.TEXT_PLAIN_VALUE)
+    @PostMapping(value = "/login/{provider}")
     public ResponseEntity<LoginResponse> login(
             @Parameter(description = "소셜 로그인 제공자 (kakao, naver)", required = true)
             @PathVariable("provider") ProviderType provider,
@@ -44,7 +44,7 @@ public class MobileAuthController {
             summary = "액세스 토큰 재발급",
             description = "리프레시 토큰이 유효하다면, 새로운 액세스 토큰 발급"
     )
-    @PostMapping(value = "/reissue-token", consumes = MediaType.TEXT_PLAIN_VALUE)
+    @PostMapping(value = "/reissue-token")
     public ResponseEntity<TokenInfo> reissueToken(@RequestBody String refreshToken) {
 
         TokenInfo tokenInfo = authService.reissueToken(refreshToken);


### PR DESCRIPTION
## 🔍 이 PR에서 해결하고자 하는 문제는 무엇인가요?

- MobileAuthController의 일부 엔드포인트에서 consumes = MediaType.TEXT_PLAIN_VALUE가 불필요하게 강제됨
- 이는 클라이언트에서 JSON 요청을 보낼 때 불필요한 제약을 만들어 호환성 저하 문제 발생

## ✨ 이 PR에서 주요하게 변경한 점은 무엇인가요?

- /login/{provider}, /reissue-token 엔드포인트에서 consumes 옵션 제거
- 기본 요청 본문 처리(JSON, Plain Text 등) 지원

## 🔖 주요 변경점 외에 추가로 변경된 부분이 있나요?

없음

## 🙏🏻 Reviewer가 특히 확인해주었으면 하는 부분이 있나요?

없음

## 🩺 이 PR에서 테스트나 검증이 필요한 부분이 있나요?

- 카카오/네이버 로그인 요청 시 JSON 바디로 전달되는 경우 정상 동작 확인
- Refresh Token 재발급 요청 시 JSON 형식과 plain text 모두 처리 가능한지 확인

## 📚 관련된 Issue, Jira, 문서

Issue: #81 

